### PR TITLE
Add deepCSV; centrally choose mistag flavours

### DIFF
--- a/plotProducer/scripts/plotConfiguration.py
+++ b/plotProducer/scripts/plotConfiguration.py
@@ -22,28 +22,33 @@ EtaPtBin =[
 # list of taggers to look at, divided in B- or C-taggers
 # (needed to distinguish performance plots)
 listTagB = [
-    #"CSV",
 	"CSVv2",
-	#"combMVA",
 	"combMVAv2",
-    #"CSVMVA",
+    "deepCSV_probb",
+    "deepCSV_probudsg",
+    "deepCSV_probbb",
     "JP",
     "JBP",
     "TCHE",
-    #"TCHP",
-    #"SSVHE",
     "SISVHE",
-    #"SSVHP",
     "SMT",
     "SET",
 ]
+mistagFlavors_tagB = ["C", "DUSG"]
+#mistagFlavors_tagB = ["C", "NI"]
 
-listTagC = [
-    "Ctagger_CvsB",
+listTagC_vs_L = [
+    "deepCSV_probc",
     "Ctagger_CvsL"
 ]
+mistagFlavors_tagC_vs_L = ["DUSG"]
 
-listTagger = listTagB + listTagC
+listTagC_vs_B = [
+    "Ctagger_CvsB",
+]
+mistagFlavors_tagC_vs_B = ["B"]
+
+listTagger = listTagB + listTagC_vs_L + listTagC_vs_B
 
 # List of flavors to look at for non-performance plots
 listFlavors = [
@@ -57,10 +62,6 @@ listFlavors = [
         #"NI",
 ]
 
-# list of additional flavors (beside the usual ones) the performance plots should be done against
-#additionalMistagFlavors = ["PU"]
-additionalMistagFlavors = []
-
 # map for marker color for flav-col and tag-col
 mapColor = {
     "ALL"  : 4 ,
@@ -69,20 +70,20 @@ mapColor = {
     "G"    : 860 ,
     "DUS"  : 860 ,
     "DUSG" : 860 ,
-    "NI"   : 5 ,
+    "NI"   : 860,#5 ,
 	"PU"   : 6 ,
     
-    "CSV"       : 5 ,
 	"CSVv2"		: 15 ,
-	"combMVA"   : 6 ,
 	"combMVAv2"   : 16 ,
+    "deepCSV_probb" : 2,
+    "deepCSV_probc" : 5,
+    "deepCSV_probudsg" : 6,
+    "deepCSV_probbb" : 7,
     "JP"        : 3 ,
     "JBP"       : 9 ,
     "TCHE"      : 1,
-    "TCHP"      : 2,
     "SSVHE"     : 4,
     "SISVHE"     : 7,
-    "SSVHP"     : 7,
     "SMT"       : 8 ,
     "SET"       : 13 ,
 

--- a/plotProducer/scripts/plotFactory.py
+++ b/plotProducer/scripts/plotFactory.py
@@ -173,7 +173,7 @@ for bin in plotConfiguration.EtaPtBin:
                     saveName=saveName,
                     listFormats=plotConfiguration.listFormats,
                     histoCfg=histo,
-                    histos=valHistos.values() + refHistos.values(),
+                    histos=refHistos.values() + valHistos.values(),
                     options=options,
                     ratiosX=ratiosXList,
                     ratiosY=ratiosYList,
@@ -183,7 +183,7 @@ for bin in plotConfiguration.EtaPtBin:
         
         # for FlavEffVsBEff_B_discr (performance summaries)
         if histo.name == "FlavEffVsBEff_B_discr":
-            for flav in ["C", "DUSG"]:
+            for flav in plotConfiguration.mistagFlavors_tagB:
                 for isVal in [True, False]:
                     # setup the histos
                     if isVal: Histos = plotProducer.histoProducer(histoCfg=histo, histos=perfAll_Val[flav], isVal=isVal)

--- a/plotProducer/scripts/plotList.py
+++ b/plotProducer/scripts/plotList.py
@@ -20,7 +20,7 @@ class plotInfo :
                   binning=None, Rebin=None,
                   doNormalization=False,
                   listTagger=None, listFlavors=None,
-                  doPerformance=False, tagFlavor="B", mistagFlavor=["C","DUSG"]):
+                  doPerformance=False, tagFlavor="B", mistagFlavor=plotConfiguration.mistagFlavors_tagB):
         self.name = name                        # name of the histos without postfix as PT/ETA bin or flavor
         self.title = title                      # title of the histograms : better if specific for the histogram
         self.legend = legend                    # legend name, if contain 'KEY', it will be replace by the list of keys you provide (as flavor, tagger ...)
@@ -77,7 +77,8 @@ jetEta = plotInfo(name="jetEta",
                   Xlabel="#eta", 
                   Ylabel="Arbitrary units",
                   logY=False, grid=False,
-                  binning=[11,90], Rebin=4, 
+                  binning=[11,90],
+                  Rebin=4, 
                   doNormalization=True,
                   listTagger=["CSVv2"]
                   )
@@ -134,7 +135,7 @@ performance = plotInfo(name="effVsDiscrCut_discr",
                        logY=True, grid=True, 
                        doPerformance=True, 
                        tagFlavor="B", 
-                       mistagFlavor=["C", "DUSG"] + plotConfiguration.additionalMistagFlavors,
+                       mistagFlavor=plotConfiguration.mistagFlavors_tagB,
                        listTagger=plotConfiguration.listTagB
                        )
 
@@ -148,8 +149,8 @@ performanceCvsB = plotInfo(name="effVsDiscrCut_discr",
                         logY=True, grid=True, 
                         doPerformance=True, 
                         tagFlavor="C", 
-                        mistagFlavor=["B"] + plotConfiguration.additionalMistagFlavors,
-                        listTagger=["Ctagger_CvsB"]
+                        mistagFlavor=plotConfiguration.mistagFlavors_tagC_vs_B,
+                        listTagger=listTagC_vs_B
                        )
 
 # MC only, to do C vs light
@@ -162,8 +163,8 @@ performanceCvsL = plotInfo(name="effVsDiscrCut_discr",
                         logY=True, grid=True, 
                         doPerformance=True, 
                         tagFlavor="C", 
-                        mistagFlavor=["DUSG"] + plotConfiguration.additionalMistagFlavors,
-                        listTagger=["Ctagger_CvsL"]
+                        mistagFlavor=plotConfiguration.mistagFlavors_tagC_vs_L,
+                        listTagger=listTagC_vs_L 
                        )
 
 # track infos
@@ -625,6 +626,66 @@ trackPParRatio = plotInfo(name="trackPParRatio",
                           listTagger=["CSVTag"]
                           )
 
+leptonDeltaR = plotInfo(name="leptonDeltaR",
+                          title="momentum of the soft lepton over jet energy",
+                          legend="isVal KEY-jets",
+                          legendPosition="top-left",
+                          Xlabel="momentum of the soft lepton over jet energy",
+                          Ylabel="Arbitrary units",
+                          logY=False, grid=False,
+                          binning=None, Rebin=None,
+                          doNormalization=True,
+                          listTagger=["CtaggerTag"]
+                          )
+
+leptonEtaRel = plotInfo(name="leptonEtaRel",
+                          title="pseudo-angular distance of the soft lepton to jet axis",
+                          legend="isVal KEY-jets",
+                          legendPosition="top-left",
+                          Xlabel="pseudo-angular distance of the soft lepton to jet axis",
+                          Ylabel="Arbitrary units",
+                          logY=False, grid=False,
+                          binning=None, Rebin=None,
+                          doNormalization=True,
+                          listTagger=["CtaggerTag"]
+                          )
+
+leptonPtRel = plotInfo(name="leptonPtRel",
+                          title="momentum of the soft lepton along the jet direction, in the jet rest frame",
+                          legend="isVal KEY-jets",
+                          legendPosition="top-left",
+                          Xlabel="momentum of the soft lepton along the jet direction, in the jet rest frame",
+                          Ylabel="Arbitrary units",
+                          logY=False, grid=False,
+                          binning=None, Rebin=None,
+                          doNormalization=True,
+                          listTagger=["CtaggerTag"]
+                          )
+
+leptonRatio = plotInfo(name="leptonRatio",
+                          title="momentum of the soft lepton parallel to jet axis over jet energy",
+                          legend="isVal KEY-jets",
+                          legendPosition="top-left",
+                          Xlabel="momentum of the soft lepton parallel to jet axis over jet energy",
+                          Ylabel="Arbitrary units",
+                          logY=False, grid=False,
+                          binning=None, Rebin=None,
+                          doNormalization=True,
+                          listTagger=["CtaggerTag"]
+                          )
+
+leptonSip3d = plotInfo(name="leptonSip3d",
+                          title="IP significance of soft lepton",
+                          legend="isVal KEY-jets",
+                          legendPosition="top-left",
+                          Xlabel="IP significance of soft lepton",
+                          Ylabel="Arbitrary units",
+                          logY=False, grid=False,
+                          binning=None, Rebin=None,
+                          doNormalization=True,
+                          listTagger=["CtaggerTag"]
+                          )
+
 # list of histos to plots
 listHistos = [
     ##### Kinematic
@@ -679,5 +740,11 @@ listHistos = [
     trackNHits,
     trackNPixelHits,
     trackNormChi2,
+
+    leptonDeltaR,
+    leptonEtaRel,
+    leptonPtRel,
+    leptonRatio,
+    leptonSip3d
 ]
 

--- a/plotProducer/scripts/plotProducer.py
+++ b/plotProducer/scripts/plotProducer.py
@@ -259,6 +259,11 @@ def savePlots(title, saveName, listFormats, histoCfg, histos, keyHisto, listLege
             if not histoCfg.doPerformance: h.GetPainter().PaintStat(ROOT.gStyle.GetOptStat(), 0)
             h.SetTitle(title)
             h.Draw(option)
+            ### FIX RANGE
+            if histoCfg.doPerformance:
+                h.GetXaxis().SetRangeUser(0,1)
+                h.Draw(option)
+                pads["hist"].Update()
             xHistMin = h.GetXaxis().GetXmin()
             xHistMax = h.GetXaxis().GetXmax()
             first = False


### PR DESCRIPTION
Add the deepCSV, present since 92X.
Warning: Performance curves are to be taken with a grain of salt since what is plotted is the different outputs separately: probb, probbb, probc, probdusg.

Also included are some soft lepton tag infos used e.g. for the ctagger.

Changing in only one file which mistag flavours are used is useful when validating miniAOD, where all the "light" jets fall into the "NI" category (and not the usual "DUSG").

This comes with the latest version of the validation scripts found at https://gist.github.com/swertz/97150f239b9528c923af