### PR TITLE
Easily run validation on data

### DIFF
--- a/plotProducer/scripts/plotConfiguration.py
+++ b/plotProducer/scripts/plotConfiguration.py
@@ -22,8 +22,8 @@ EtaPtBin =[
 # list of taggers to look at, divided in B- or C-taggers
 # (needed to distinguish performance plots)
 listTagB = [
-	"CSVv2",
-	"combMVAv2",
+    "CSVv2",
+    "combMVAv2",
     "deepCSV_probb",
     "deepCSV_probudsg",
     "deepCSV_probbb",
@@ -58,35 +58,35 @@ listFlavors = [
         #"G",
         #"DUS",
         "DUSG",
-		#"PU",
+        #"PU",
         #"NI",
 ]
 
 # map for marker color for flav-col and tag-col
 mapColor = {
-    "ALL"  : 4 ,
-    "B"    : 633 ,
-    "C"    : 418 ,
-    "G"    : 860 ,
-    "DUS"  : 860 ,
-    "DUSG" : 860 ,
-    #"NI"   : 860 ,
-    "NI"   : 5 ,
-	"PU"   : 6 ,
+    "ALL"  : 4,
+    "B"    : 633,
+    "C"    : 418,
+    "G"    : 860,
+    "DUS"  : 860,
+    "DUSG" : 860,
+    #"NI"   : 860,
+    "NI"   : 5,
+    "PU"   : 6,
     
-	"CSVv2"		: 15 ,
-	"combMVAv2"   : 16 ,
+    "CSVv2"       : 15,
+    "combMVAv2"   : 16,
     "deepCSV_probb" : 2,
     "deepCSV_probc" : 5,
     "deepCSV_probudsg" : 6,
     "deepCSV_probbb" : 7,
-    "JP"        : 3 ,
-    "JBP"       : 9 ,
+    "JP"        : 3,
+    "JBP"       : 9,
     "TCHE"      : 1,
     "SSVHE"     : 4,
     "SISVHE"     : 7,
-    "SMT"       : 8 ,
-    "SET"       : 13 ,
+    "SMT"       : 8,
+    "SET"       : 13,
 
     # c-tagger correlation working points
     "500000"   : 633,

--- a/plotProducer/scripts/plotList.py
+++ b/plotProducer/scripts/plotList.py
@@ -20,7 +20,8 @@ class plotInfo :
                   binning=None, Rebin=None,
                   doNormalization=False,
                   listTagger=None, listFlavors=None,
-                  doPerformance=False, tagFlavor="B", mistagFlavor=plotConfiguration.mistagFlavors_tagB):
+                  doPerformance=False, notOnData=False,
+                  tagFlavor="B", mistagFlavor=plotConfiguration.mistagFlavors_tagB):
         self.name = name                        # name of the histos without postfix as PT/ETA bin or flavor
         self.title = title                      # title of the histograms : better if specific for the histogram
         self.legend = legend                    # legend name, if contain 'KEY', it will be replace by the list of keys you provide (as flavor, tagger ...)
@@ -41,6 +42,7 @@ class plotInfo :
             self.legend = legend.replace("TAG", tagFlavor)
             self.tagFlavor = tagFlavor
             self.mistagFlavor = mistagFlavor
+        self.notOnData = notOnData              # when running on data, don't produce the plot if set to True (e.g. performance plots)
         if listTagger is None:
             self.listTagger = plotConfiguration.listTagger # take the list of tagger defined centrally
         else:
@@ -120,7 +122,8 @@ correlationC = plotInfo(name="pfCombinedCvsBJetTags_vs_pfCombinedCvsLJetTags",
                  Ylabel="B mistag",
                  listTagger=["TagCorrelation"],
                  # For c-tagger correlation, "flavor" represents the different c efficiency working points
-                 listFlavors=["500000","400000","300000","200000"]
+                 listFlavors=["500000","400000","300000","200000"],
+                 notOnData=True
                  )
 
 effVsDiscrCut_discr = plotInfo(name="effVsDiscrCut_discr", 
@@ -140,7 +143,8 @@ FlavEffVsBEff_discr = plotInfo(name="FlavEffVsBEff_B_discr",
                                Xlabel="b-tag efficiency", 
                                Ylabel="Non b-tag efficiency",
                                logY=True, grid=True,
-                               listTagger=plotConfiguration.listTagB
+                               listTagger=plotConfiguration.listTagB,
+                               notOnData=True
                                )
 
 # MC only
@@ -154,7 +158,8 @@ performance = plotInfo(name="effVsDiscrCut_discr",
                        doPerformance=True, 
                        tagFlavor="B", 
                        mistagFlavor=plotConfiguration.mistagFlavors_tagB,
-                       listTagger=plotConfiguration.listTagB
+                       listTagger=plotConfiguration.listTagB,
+                       notOnData=True
                        )
 
 # MC only, to do C vs B
@@ -168,7 +173,8 @@ performanceCvsB = plotInfo(name="effVsDiscrCut_discr",
                         doPerformance=True, 
                         tagFlavor="C", 
                         mistagFlavor=plotConfiguration.mistagFlavors_tagC_vs_B,
-                        listTagger=plotConfiguration.listTagC_vs_B
+                        listTagger=plotConfiguration.listTagC_vs_B,
+                        notOnData=True
                        )
 
 # MC only, to do C vs light
@@ -182,7 +188,8 @@ performanceCvsL = plotInfo(name="effVsDiscrCut_discr",
                         doPerformance=True, 
                         tagFlavor="C", 
                         mistagFlavor=plotConfiguration.mistagFlavors_tagC_vs_L,
-                        listTagger=plotConfiguration.listTagC_vs_L 
+                        listTagger=plotConfiguration.listTagC_vs_L,
+                        notOnData=True
                        )
 
 # track infos

--- a/plotProducer/scripts/plotProducer.py
+++ b/plotProducer/scripts/plotProducer.py
@@ -7,17 +7,20 @@
 
 #######
 
+from __future__ import print_function
+from __future__ import division
+
 import os, sys
 
 try:
     import ROOT
 except:
-    print "\nCannot load PYROOT, make sure you have setup ROOT in the path"
-    print "and pyroot library is also defined in the variable PYTHONPATH, try:\n"
+    print("\nCannot load PYROOT, make sure you have setup ROOT in the path")
+    print("and pyroot library is also defined in the variable PYTHONPATH, try:\n")
     if (os.getenv("PYTHONPATH")):
-        print " setenv PYTHONPATH ${PYTHONPATH}:$ROOTSYS/lib\n"
+        print(" setenv PYTHONPATH ${PYTHONPATH}:$ROOTSYS/lib\n")
     else:
-        print " setenv PYTHONPATH $ROOTSYS/lib\n"
+        print(" setenv PYTHONPATH $ROOTSYS/lib\n")
         sys.exit()
 
 from ROOT import TFile
@@ -137,7 +140,7 @@ def performanceGraphProducer(histoCfg, histos, tagFlav="B", mistagFlav=["C", "DU
     g = {}
     g_out = {}
     if tagFlav not in plotConfiguration.listFlavors:
-        print "Error in graphProducer: unknown flavour"
+        print("Error in graphProducer: unknown flavour")
         return
     if histoCfg.tagFlavor and histoCfg.mistagFlavor:
         tagFlav = histoCfg.tagFlavor
@@ -356,7 +359,7 @@ def savePlots(title, saveName, listFormats, histoCfg, histos, keyHisto, listLege
     # Draw banner
     tex = None
     if options.printBanner:
-        print type(options.printBanner)
+        print(type(options.printBanner))
         tex = TLatex(0.55, 0.75, options.Banner)
         tex.SetNDC()
         tex.SetTextSize(0.05)
@@ -366,7 +369,7 @@ def savePlots(title, saveName, listFormats, histoCfg, histos, keyHisto, listLege
    
     if ratiosX:
         pos = 0
-        for flav in sorted(ratiosX.keys()):
+        for flav in sorted(list(ratiosX.keys())):
             if ratiosX[flav] is None: continue
            
             padName = "ratioX_" + flav
@@ -401,7 +404,7 @@ def savePlots(title, saveName, listFormats, histoCfg, histos, keyHisto, listLege
     
     if ratiosY:
         pos = 0
-        for flav in sorted(ratiosY.keys()):
+        for flav in sorted(list(ratiosY.keys())):
             if ratiosY[flav] is None: continue
             
             padName = "ratioY_" + flav


### PR DESCRIPTION
Add an argument to the plotting script to only produce the plots available when validating data RelVals.

Alternatively, set the `RUN_ON_DATA` environment variable in the comparison shell script.